### PR TITLE
docs(tab): fix wrong code examples

### DIFF
--- a/src/content/docs/tab/api/core.mdx
+++ b/src/content/docs/tab/api/core.mdx
@@ -43,7 +43,7 @@ const buildCmd = t.command('dev build', 'Build project');
 Adds a global option to the root command.
 
 **Parameters:**
-- `name` (string): The option name (e.g., '--config')
+- `name` (string): The option name (e.g., 'config' for '--config')
 - `description` (string): Option description
 - `handler` (OptionHandler, optional): Function that provides completion suggestions
 - `alias` (string, optional): Short flag alias (e.g., 'c' for '--config')
@@ -52,7 +52,7 @@ Adds a global option to the root command.
 
 **Example:**
 ```ts
-t.option('--config', 'Use specified config file', function(complete) {
+t.option('config', 'Use specified config file', function(complete) {
   complete('vite.config.ts', 'Vite config file');
   complete('vite.config.js', 'Vite config file');
 }, 'c');
@@ -120,7 +120,7 @@ const cmd = t.command('dev', 'Start development server');
 Adds an option to this command.
 
 **Parameters:**
-- `name` (string): The option name (e.g., '--port')
+- `name` (string): The option name (e.g., 'p' for '--port')
 - `description` (string): Option description
 - `handler` (OptionHandler, optional): Function that provides completion suggestions
 - `alias` (string, optional): Short flag alias (e.g., 'p' for '--port')
@@ -129,7 +129,7 @@ Adds an option to this command.
 
 **Example:**
 ```ts
-cmd.option('--port', 'Port number', function(complete) {
+cmd.option('port', 'Port number', function(complete) {
   complete('3000', 'Development port');
   complete('8080', 'Production port');
 }, 'p');
@@ -279,12 +279,12 @@ import { RootCommand } from '@bomb.sh/tab';
 const t = new RootCommand();
 
 // Add global options
-t.option('--config', 'Use specified config file', function(complete) {
+t.option('config', 'Use specified config file', function(complete) {
   complete('vite.config.ts', 'Vite config file');
   complete('vite.config.js', 'Vite config file');
 }, 'c');
 
-t.option('--mode', 'Set env mode', function(complete) {
+t.option('mode', 'Set env mode', function(complete) {
   complete('development', 'Development mode');
   complete('production', 'Production mode');
 }, 'm');
@@ -297,17 +297,17 @@ t.argument('project', function(complete) {
 
 // Add commands with completions
 const devCmd = t.command('dev', 'Start development server');
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', 'Development port');
   complete('8080', 'Production port');
 }, 'p');
 
-devCmd.option('--host', 'Hostname', function(complete) {
+devCmd.option('host', 'Hostname', function(complete) {
   complete('localhost', 'Localhost');
   complete('0.0.0.0', 'All interfaces');
 }, 'H');
 
-devCmd.option('--verbose', 'Enable verbose logging', 'v');
+devCmd.option('verbose', 'Enable verbose logging', 'v');
 
 // Add nested commands
 t.command('dev build', 'Build project');
@@ -356,7 +356,7 @@ if (process.argv[2] === 'complete') {
 Make your completions responsive to what the user is typing:
 
 ```ts
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   // Check if user is typing a specific port
   if (this.toComplete?.startsWith('30')) {
     complete('3000', 'Development port');
@@ -374,7 +374,7 @@ devCmd.option('--port', 'Port number', function(complete) {
 Load completions from external sources:
 
 ```ts
-devCmd.option('--config', 'Config file', async function(complete) {
+devCmd.option('config', 'Config file', async function(complete) {
   try {
     const files = await fs.readdir('.');
     const configFiles = files.filter(f => f.includes('config'));
@@ -391,8 +391,8 @@ devCmd.option('--config', 'Config file', async function(complete) {
 For boolean flags, you don't need a handler:
 
 ```ts
-devCmd.option('--verbose', 'Enable verbose logging', 'v');
-devCmd.option('--quiet', 'Suppress output');
+devCmd.option('verbose', 'Enable verbose logging', 'v');
+devCmd.option('quiet', 'Suppress output');
 ```
 
 ## Next Steps

--- a/src/content/docs/tab/basics/getting-started.mdx
+++ b/src/content/docs/tab/basics/getting-started.mdx
@@ -39,19 +39,19 @@ import { RootCommand } from '@bomb.sh/tab';
 const t = new RootCommand();
 
 // Add global options
-t.option('--config', 'Use specified config file', function(complete) {
+t.option('config', 'Use specified config file', function(complete) {
   complete('vite.config.ts', 'Vite config file');
   complete('vite.config.js', 'Vite config file');
 }, 'c');
 
 // Add commands with completions
 const devCmd = t.command('dev', 'Start development server');
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', 'Development port');
   complete('8080', 'Production port');
 }, 'p');
 
-devCmd.option('--host', 'Hostname', function(complete) {
+devCmd.option('host', 'Hostname', function(complete) {
   complete('localhost', 'Localhost');
   complete('0.0.0.0', 'All interfaces');
 }, 'H');
@@ -108,7 +108,7 @@ const devCmd = t.command('dev', 'Start development server');
 Add options to commands with completion handlers:
 
 ```ts
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', 'Development port');
   complete('8080', 'Production port');
 }, 'p'); // Short flag alias

--- a/src/content/docs/tab/guides/adapters.mdx
+++ b/src/content/docs/tab/guides/adapters.mdx
@@ -15,31 +15,27 @@ import tab from '@bomb.sh/tab/cac';
 
 const cli = cac('my-cli');
 
-cli.command('dev', 'Start dev server').option('--port <port>', 'Specify port');
-cli.command('build', 'Build for production').option('--mode <mode>', 'Build mode');
+cli.command('dev', 'Start dev server').option('port <port>', 'Specify port');
+cli.command('build', 'Build for production').option('mode <mode>', 'Build mode');
 
-const completion = tab(cli);
+const completion = await tab(cli);
 
 // Get the dev command completion handler
 const devCommandCompletion = completion.commands.get('dev');
 
 // Get and configure the port option completion handler
-const portOptionCompletion = devCommandCompletion.options.get('--port');
-portOptionCompletion.handler = async () => {
-  return [
-    { value: '3000', description: 'Development port' },
-    { value: '8080', description: 'Production port' },
-  ];
+const portOptionCompletion = devCommandCompletion.options.get('port');
+portOptionCompletion.handler = (complete) => {
+  complete('3000', 'Development port');
+  complete('8080', 'Production port');
 };
 
 // Configure build mode completions
 const buildCommandCompletion = completion.commands.get('build');
-const modeOptionCompletion = buildCommandCompletion.options.get('--mode');
-modeOptionCompletion.handler = async () => {
-  return [
-    { value: 'development', description: 'Development build' },
-    { value: 'production', description: 'Production build' },
-  ];
+const modeOptionCompletion = buildCommandCompletion.options.get('mode');
+modeOptionCompletion.handler = (complete) => {
+  complete('development', 'Development build');
+  complete('production', 'Production build');
 };
 
 cli.parse();
@@ -100,13 +96,11 @@ const completion = await tab(main);
 // Configure completions
 const devCommandCompletion = completion.commands.get('dev');
 if (devCommandCompletion) {
-  const portOptionCompletion = devCommandCompletion.options.get('--port');
+  const portOptionCompletion = devCommandCompletion.options.get('port');
   if (portOptionCompletion) {
-    portOptionCompletion.handler = async () => {
-      return [
-        { value: '3000', description: 'Development port' },
-        { value: '8080', description: 'Production port' },
-      ];
+    portOptionCompletion.handler = (complete) => {
+      complete('3000', 'Development port');
+      complete('8080', 'Production port');
     };
   }
 }
@@ -154,13 +148,11 @@ const completion = tab(program);
 // Configure completions
 const devCommandCompletion = completion.commands.get('dev');
 if (devCommandCompletion) {
-  const portOptionCompletion = devCommandCompletion.options.get('--port');
+  const portOptionCompletion = devCommandCompletion.options.get('port');
   if (portOptionCompletion) {
-    portOptionCompletion.handler = async () => {
-      return [
-        { value: '3000', description: 'Development port' },
-        { value: '8080', description: 'Production port' },
-      ];
+    portOptionCompletion.handler = (complete) => {
+      complete('3000', 'Development port');
+      complete('8080', 'Production port');
     };
   }
 }

--- a/src/content/docs/tab/guides/best-practices.mdx
+++ b/src/content/docs/tab/guides/best-practices.mdx
@@ -13,14 +13,14 @@ Always include descriptive text for your completions to help users understand wh
 
 ```ts
 // Good
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', 'Development port (default)');
   complete('8080', 'Production port');
   complete('9000', 'Alternative port');
 }, 'p');
 
 // Avoid
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', '');
   complete('8080', '');
 }, 'p');
@@ -31,7 +31,7 @@ devCmd.option('--port', 'Port number', function(complete) {
 Make your completions responsive to what the user is typing:
 
 ```ts
-devCmd.option('--mode', 'Build mode', function(complete) {
+devCmd.option('mode', 'Build mode', function(complete) {
   // If user is typing 'dev', suggest development
   if (this.toComplete?.startsWith('dev')) {
     complete('development', 'Development mode');
@@ -56,7 +56,7 @@ devCmd.option('--mode', 'Build mode', function(complete) {
 Always handle errors in your completion handlers to prevent crashes:
 
 ```ts
-devCmd.option('--config', 'Config file', async function(complete) {
+devCmd.option('config', 'Config file', async function(complete) {
   try {
     const files = await fs.readdir('.');
     const configFiles = files.filter(f => f.includes('config'));
@@ -136,15 +136,15 @@ Provide short aliases only for commonly used options:
 
 ```ts
 // Good - short aliases for common options
-devCmd.option('--port', 'Port number', handler, 'p');
-devCmd.option('--host', 'Host address', handler, 'h');
-devCmd.option('--verbose', 'Enable verbose logging', 'v');
+devCmd.option('port', 'Port number', handler, 'p');
+devCmd.option('host', 'Host address', handler, 'h');
+devCmd.option('verbose', 'Enable verbose logging', 'v');
 
 // Avoid - too many short aliases
-devCmd.option('--config', 'Config file', handler, 'c');
-devCmd.option('--mode', 'Build mode', handler, 'm');
-devCmd.option('--output', 'Output directory', handler, 'o');
-devCmd.option('--source', 'Source directory', handler, 's');
+devCmd.option('config', 'Config file', handler, 'c');
+devCmd.option('mode', 'Build mode', handler, 'm');
+devCmd.option('output', 'Output directory', handler, 'o');
+devCmd.option('source', 'Source directory', handler, 's');
 ```
 
 ## Option Design Best Practices
@@ -155,12 +155,12 @@ Use boolean flags for simple on/off options:
 
 ```ts
 // Good - boolean flags for simple options
-devCmd.option('--verbose', 'Enable verbose logging', 'v');
-devCmd.option('--quiet', 'Suppress output', 'q');
-devCmd.option('--watch', 'Watch for changes', 'w');
+devCmd.option('verbose', 'Enable verbose logging', 'v');
+devCmd.option('quiet', 'Suppress output', 'q');
+devCmd.option('watch', 'Watch for changes', 'w');
 
 // Good - value options for complex data
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', 'Development port');
   complete('8080', 'Production port');
 }, 'p');
@@ -171,7 +171,7 @@ devCmd.option('--port', 'Port number', function(complete) {
 When possible, provide sensible default values in your suggestions:
 
 ```ts
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', 'Development port (default)');
   complete('8080', 'Production port');
   complete('9000', 'Alternative port');
@@ -184,12 +184,12 @@ Choose option names that clearly indicate their purpose:
 
 ```ts
 // Good - descriptive names
-devCmd.option('--output-dir', 'Output directory', handler);
-devCmd.option('--source-map', 'Generate source maps', handler);
+devCmd.option('output-dir', 'Output directory', handler);
+devCmd.option('source-map', 'Generate source maps', handler);
 
 // Avoid - ambiguous names
-devCmd.option('--output', 'Output directory', handler);
-devCmd.option('--map', 'Generate source maps', handler);
+devCmd.option('output', 'Output directory', handler);
+devCmd.option('map', 'Generate source maps', handler);
 ```
 
 ## Argument Design Best Practices
@@ -268,9 +268,9 @@ For package manager integration, provide completions for all major commands:
 ```ts
 // Example: Comprehensive pnpm completions
 const addCmd = t.command('add', 'Install packages');
-addCmd.option('--save-dev', 'Save to devDependencies', 'D');
-addCmd.option('--save-optional', 'Save to optionalDependencies', 'O');
-addCmd.option('--global', 'Install globally', 'g');
+addCmd.option('save-dev', 'Save to devDependencies', 'D');
+addCmd.option('save-optional', 'Save to optionalDependencies', 'O');
+addCmd.option('global', 'Install globally', 'g');
 
 const runCmd = t.command('run', 'Run scripts');
 runCmd.argument('script', async function(complete) {
@@ -323,7 +323,7 @@ t.command('remove', 'Remove packages')
 Limit the number of completions to maintain performance:
 
 ```ts
-devCmd.option('--config', 'Config file', async function(complete) {
+devCmd.option('config', 'Config file', async function(complete) {
   try {
     const files = await fs.readdir('.');
     const configFiles = files.filter(f => f.includes('config'));
@@ -341,14 +341,14 @@ Only use async operations when necessary:
 
 ```ts
 // Good - sync operations for simple completions
-devCmd.option('--mode', 'Build mode', function(complete) {
+devCmd.option('mode', 'Build mode', function(complete) {
   complete('development', 'Development mode');
   complete('production', 'Production mode');
   complete('staging', 'Staging mode');
 });
 
 // Good - async operations for dynamic data
-devCmd.option('--config', 'Config file', async function(complete) {
+devCmd.option('config', 'Config file', async function(complete) {
   const files = await fs.readdir('.');
   const configFiles = files.filter(f => f.includes('config'));
   configFiles.forEach(file => complete(file, `Config file: ${file}`));
@@ -362,7 +362,7 @@ devCmd.option('--config', 'Config file', async function(complete) {
 Start with common options and provide more specific ones as users type:
 
 ```ts
-devCmd.option('--mode', 'Build mode', function(complete) {
+devCmd.option('mode', 'Build mode', function(complete) {
   if (this.toComplete?.startsWith('dev')) {
     complete('development', 'Development mode');
     return;
@@ -387,14 +387,14 @@ Maintain consistent description formatting:
 
 ```ts
 // Good - consistent formatting
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', 'Development port (default)');
   complete('8080', 'Production port');
   complete('9000', 'Alternative port');
 }, 'p');
 
 // Avoid - inconsistent formatting
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', 'dev port');
   complete('8080', 'Production port');
   complete('9000', 'alt port');
@@ -406,12 +406,12 @@ devCmd.option('--port', 'Port number', function(complete) {
 Include default values in descriptions when helpful:
 
 ```ts
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', 'Development port (default)');
   complete('8080', 'Production port');
 }, 'p');
 
-devCmd.option('--host', 'Host address', function(complete) {
+devCmd.option('host', 'Host address', function(complete) {
   complete('localhost', 'Localhost (default)');
   complete('0.0.0.0', 'All interfaces');
 }, 'h');
@@ -443,7 +443,7 @@ Test how your completions handle error conditions:
 
 ```ts
 // Test with missing files
-devCmd.option('--config', 'Config file', async function(complete) {
+devCmd.option('config', 'Config file', async function(complete) {
   try {
     const files = await fs.readdir('.');
     const configFiles = files.filter(f => f.includes('config'));
@@ -462,7 +462,7 @@ Monitor completion performance, especially for async operations:
 
 ```ts
 // Add timing for performance monitoring
-devCmd.option('--config', 'Config file', async function(complete) {
+devCmd.option('config', 'Config file', async function(complete) {
   const start = Date.now();
   try {
     const files = await fs.readdir('.');

--- a/src/content/docs/tab/guides/examples.mdx
+++ b/src/content/docs/tab/guides/examples.mdx
@@ -16,12 +16,12 @@ import { RootCommand } from '@bomb.sh/tab';
 const t = new RootCommand();
 
 // Add global options
-t.option('--config', 'Use specified config file', function(complete) {
+t.option('config', 'Use specified config file', function(complete) {
   complete('vite.config.ts', 'Vite config file');
   complete('vite.config.js', 'Vite config file');
 }, 'c');
 
-t.option('--mode', 'Set env mode', function(complete) {
+t.option('mode', 'Set env mode', function(complete) {
   complete('development', 'Development mode');
   complete('production', 'Production mode');
 }, 'm');
@@ -34,26 +34,26 @@ t.argument('project', function(complete) {
 
 // Add commands with completions
 const devCmd = t.command('dev', 'Start development server');
-devCmd.option('--port', 'Port number', function(complete) {
+devCmd.option('port', 'Port number', function(complete) {
   complete('3000', 'Development port');
   complete('8080', 'Production port');
 }, 'p');
 
-devCmd.option('--host', 'Host address', function(complete) {
+devCmd.option('host', 'Host address', function(complete) {
   complete('localhost', 'Local development');
   complete('0.0.0.0', 'All interfaces');
 }, 'h');
 
-devCmd.option('--verbose', 'Enable verbose logging', 'v');
+devCmd.option('verbose', 'Enable verbose logging', 'v');
 
 // Add build command
 const buildCmd = t.command('build', 'Build for production');
-buildCmd.option('--mode', 'Build mode', function(complete) {
+buildCmd.option('mode', 'Build mode', function(complete) {
   complete('development', 'Development build');
   complete('production', 'Production build');
 });
 
-buildCmd.option('--out-dir', 'Output directory', function(complete) {
+buildCmd.option('out-dir', 'Output directory', function(complete) {
   complete('dist/', 'Distribution directory');
   complete('build/', 'Build directory');
 });
@@ -100,63 +100,57 @@ const cli = cac('my-cli');
 
 // Define commands
 cli.command('dev', 'Start development server')
-  .option('--port <port>', 'Specify port', { default: 3000 })
-  .option('--host <host>', 'Specify host', { default: 'localhost' })
-  .option('--config <file>', 'Config file')
+  .option('port <port>', 'Specify port', { default: 3000 })
+  .option('host <host>', 'Specify host', { default: 'localhost' })
+  .option('config <file>', 'Config file')
   .action((options) => {
     console.log('Starting dev server...', options);
   });
 
 cli.command('build', 'Build for production')
-  .option('--mode <mode>', 'Build mode', { default: 'production' })
-  .option('--out-dir <dir>', 'Output directory')
+  .option('mode <mode>', 'Build mode', { default: 'production' })
+  .option('out-dir <dir>', 'Output directory')
   .action((options) => {
     console.log('Building...', options);
   });
 
 cli.command('deploy', 'Deploy application')
-  .option('--env <environment>', 'Deployment environment')
-  .option('--region <region>', 'Deployment region')
+  .option('env <environment>', 'Deployment environment')
+  .option('region <region>', 'Deployment region')
   .action((options) => {
     console.log('Deploying...', options);
   });
 
 // Initialize Tab completion
-const completion = tab(cli);
+const completion = await tab(cli);
 
 // Configure custom completions
 const devCommandCompletion = completion.commands.get('dev');
 if (devCommandCompletion) {
-  const portOptionCompletion = devCommandCompletion.options.get('--port');
+  const portOptionCompletion = devCommandCompletion.options.get('port');
   if (portOptionCompletion) {
-    portOptionCompletion.handler = async () => {
-      return [
-        { value: '3000', description: 'Development port' },
-        { value: '8080', description: 'Production port' },
-      ];
+    portOptionCompletion.handler = (complete) => {
+      complete('3000', 'Development port');
+      complete('8080', 'Production port');
     };
   }
 
-  const configOptionCompletion = devCommandCompletion.options.get('--config');
+  const configOptionCompletion = devCommandCompletion.options.get('config');
   if (configOptionCompletion) {
-    configOptionCompletion.handler = async () => {
-      return [
-        { value: 'vite.config.ts', description: 'Vite config file' },
-        { value: 'vite.config.js', description: 'Vite config file' },
-      ];
+    configOptionCompletion.handler = (complete) => {
+      complete('vite.config.ts', 'Vite config file');
+      complete('vite.config.js', 'Vite config file');
     };
   }
 }
 
 const buildCommandCompletion = completion.commands.get('build');
 if (buildCommandCompletion) {
-  const modeOptionCompletion = buildCommandCompletion.options.get('--mode');
+  const modeOptionCompletion = buildCommandCompletion.options.get('mode');
   if (modeOptionCompletion) {
-    modeOptionCompletion.handler = async () => {
-      return [
-        { value: 'development', description: 'Development build' },
-        { value: 'production', description: 'Production build' },
-      ];
+    modeOptionCompletion.handler = (complete) => {
+      complete('development', 'Development build');
+      complete('production', 'Production build');
     };
   }
 }
@@ -225,13 +219,11 @@ const completion = await tab(main);
 // Configure completions
 const devCommandCompletion = completion.commands.get('dev');
 if (devCommandCompletion) {
-  const portOptionCompletion = devCommandCompletion.options.get('--port');
+  const portOptionCompletion = devCommandCompletion.options.get('port');
   if (portOptionCompletion) {
-    portOptionCompletion.handler = async () => {
-      return [
-        { value: '3000', description: 'Development port' },
-        { value: '8080', description: 'Production port' },
-      ];
+    portOptionCompletion.handler = (complete) => {
+      complete('3000', 'Development port');
+      complete('8080', 'Production port');
     };
   }
 }
@@ -289,13 +281,11 @@ const completion = tab(program);
 // Configure completions
 const devCommandCompletion = completion.commands.get('dev');
 if (devCommandCompletion) {
-  const portOptionCompletion = devCommandCompletion.options.get('--port');
+  const portOptionCompletion = devCommandCompletion.options.get('port');
   if (portOptionCompletion) {
-    portOptionCompletion.handler = async () => {
-      return [
-        { value: '3000', description: 'Development port' },
-        { value: '8080', description: 'Production port' },
-      ];
+    portOptionCompletion.handler = (complete) => {
+      complete('3000', 'Development port');
+      complete('8080', 'Production port');
     };
   }
 }
@@ -316,7 +306,7 @@ import { RootCommand } from '@bomb.sh/tab';
 const t = new RootCommand();
 
 t.command('build', 'Build project')
-  .option('--config', 'Config file', async function(complete) {
+  .option('config', 'Config file', async function(complete) {
     try {
       const files = await readdir('.');
       const configFiles = files.filter(f => 
@@ -339,7 +329,7 @@ Provide different completions based on context:
 const t = new RootCommand();
 
 t.command('deploy', 'Deploy application')
-  .option('--env', 'Environment', function(complete) {
+  .option('env', 'Environment', function(complete) {
     // Check if user is typing a specific environment
     if (this.toComplete?.startsWith('prod')) {
       complete('production', 'Production environment');
@@ -350,7 +340,7 @@ t.command('deploy', 'Deploy application')
     complete('staging', 'Staging environment');
     complete('production', 'Production environment');
   })
-  .option('--region', 'Region', function(complete) {
+  .option('region', 'Region', function(complete) {
     // Provide region completions based on environment
     const env = this.command?.options?.get('--env')?.value;
     
@@ -401,7 +391,7 @@ import { RootCommand } from '@bomb.sh/tab';
 const t = new RootCommand();
 
 t.command('workspace', 'Workspace commands')
-  .option('--filter', 'Filter workspaces', async function(complete) {
+  .option('filter', 'Filter workspaces', async function(complete) {
     try {
       const packageJson = JSON.parse(await readFile('package.json', 'utf8'));
       const workspaces = packageJson.workspaces || [];

--- a/src/content/docs/tab/index.mdx
+++ b/src/content/docs/tab/index.mdx
@@ -50,7 +50,7 @@ const t = new RootCommand();
 
 // Add commands with completions
 t.command('dev', 'Start development server')
-  .option('--port', 'Port number', function(complete) {
+  .option('port', 'Port number', function(complete) {
     complete('3000', 'Development port');
     complete('8080', 'Production port');
   }, 'p');


### PR DESCRIPTION
The following code was not working, so I fixed it:

- `option` argument:  `--` prefix is unnecessary
- completion handler for adapters: Instead of returning completion items, we should pass them via the complete function passed to the handler.