### PR TITLE
fix: sponsor redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,4 +2,4 @@
 /on/bluesky https://bsky.app/profile/bomb.sh
 
 /chat https://discord.gg/2uEVGZSkjX
-/sponsor https://polar.sh/bombshell-dev
+/sponsor https://opencollective.com/bombshell-dev


### PR DESCRIPTION
I found an old polar link which does lead to 404. 
After confirmation on Discord, I updated it to our Open Collective page.