### PR TITLE
fix: install arktype for twoslash

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@astrojs/starlight": "^0.37.1",
     "@bomb.sh/args": "^0.3.1",
-    "@clack/core": "^1.3.0",
-    "@clack/prompts": "^1.3.0",
+    "@clack/core": "^1.4.0",
+    "@clack/prompts": "^1.5.0",
     "@types/node": "^22.19.3",
     "@webcontainer/api": "^1.6.1",
     "@webcontainer/snapshot": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "arktype": "^2.2.0",
     "astro": "^5.16.6",
     "expressive-code-twoslash": "^0.5.3",
     "sharp": "^0.33.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^0.3.1
         version: 0.3.1
       '@clack/core':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.4.0
+        version: 1.4.0
       '@clack/prompts':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.5.0
+        version: 1.5.0
       '@types/node':
         specifier: ^22.19.3
         version: 22.19.3
@@ -137,12 +137,12 @@ packages:
     resolution: {integrity: sha512-8XqW8xGn++Eqqbz3e9wKuK7mxryeRjs4LOHLxbh2lwKeSbuNR4NFifDZT4KzvjU6HMOPbiNTsWpniK5EJfTWkg==}
     engines: {node: '>=18'}
 
-  '@clack/core@1.3.0':
-    resolution: {integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==}
+  '@clack/core@1.4.0':
+    resolution: {integrity: sha512-7Wctjq6f7c1CPz8sPpkwUnz8yRgVANkpNupb81q432FjcJg4l+Sw7XANdNSdWfAKq0IHI0JTcUeK5dxs/HrGPw==}
     engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@1.3.0':
-    resolution: {integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==}
+  '@clack/prompts@1.5.0':
+    resolution: {integrity: sha512-wKh+wTjmrUoUdkZg8KpJO5X+p9PWV+KE9mePseq9UYWkukgTKsGS47RRL2HstwVcvDQH+PenrPJWII8+MfiiyA==}
     engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.4.2':
@@ -2577,14 +2577,14 @@ snapshots:
     dependencies:
       fontkit: 2.0.4
 
-  '@clack/core@1.3.0':
+  '@clack/core@1.4.0':
     dependencies:
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.3.0':
+  '@clack/prompts@1.5.0':
     dependencies:
-      '@clack/core': 1.3.0
+      '@clack/core': 1.4.0
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      arktype:
+        specifier: ^2.2.0
+        version: 2.2.0
       astro:
         specifier: ^5.16.6
         version: 5.16.6(@types/node@22.19.3)(rollup@4.55.1)(typescript@5.8.2)
@@ -68,6 +71,12 @@ importers:
         version: 4.80.0(@cloudflare/workers-types@4.20260405.1)
 
 packages:
+
+  '@ark/schema@0.56.0':
+    resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
+
+  '@ark/util@0.56.0':
+    resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
 
   '@astrojs/compiler@2.13.0':
     resolution: {integrity: sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==}
@@ -1134,6 +1143,12 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  arkregex@0.0.5:
+    resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
+
+  arktype@2.2.0:
+    resolution: {integrity: sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==}
 
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
@@ -2430,6 +2445,12 @@ packages:
 
 snapshots:
 
+  '@ark/schema@0.56.0':
+    dependencies:
+      '@ark/util': 0.56.0
+
+  '@ark/util@0.56.0': {}
+
   '@astrojs/compiler@2.13.0': {}
 
   '@astrojs/internal-helpers@0.7.5': {}
@@ -3248,6 +3269,16 @@ snapshots:
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
+
+  arkregex@0.0.5:
+    dependencies:
+      '@ark/util': 0.56.0
+
+  arktype@2.2.0:
+    dependencies:
+      '@ark/schema': 0.56.0
+      '@ark/util': 0.56.0
+      arkregex: 0.0.5
 
   array-iterate@2.0.1: {}
 

--- a/src/content/docs/clack/guides/best-practices.mdx
+++ b/src/content/docs/clack/guides/best-practices.mdx
@@ -57,12 +57,14 @@ A [Standard Schema](https://github.com/standard-schema/standard-schema) can be u
 
 ```ts twoslash
 import { text } from '@clack/prompts';
-// @errors: 2322
 import { type } from 'arktype';
 
 const name = await text({
-	message: 'Enter your name (letters only)',
-  validate: type('string.alpha').describe('Name can only contain letters'),
+  message: 'Enter your name (letters only)',
+  validate: (value) => {
+    const result = type('string.alpha').describe('Name can only contain letters')(value);
+    return result instanceof type.errors ? result.summary : undefined;
+  },
 });
 ```
 

--- a/src/content/docs/clack/guides/best-practices.mdx
+++ b/src/content/docs/clack/guides/best-practices.mdx
@@ -61,10 +61,7 @@ import { type } from 'arktype';
 
 const name = await text({
   message: 'Enter your name (letters only)',
-  validate: (value) => {
-    const result = type('string.alpha').describe('Name can only contain letters')(value);
-    return result instanceof type.errors ? result.summary : undefined;
-  },
+  validate: type('string.alpha').describe('Name can only contain letters'),
 });
 ```
 


### PR DESCRIPTION
This PR installs arktype in order for twoslash to be happy.
Blocked by https://github.com/bombshell-dev/clack/pull/539 (merged ✅)