### PR TITLE
fix(style): mobile search and menu placement and color

### DIFF
--- a/src/styles/starlight.css
+++ b/src/styles/starlight.css
@@ -151,7 +151,16 @@
     }
   }
 
-  starlight-menu-button button,
+  [data-has-sidebar] header.header {
+    padding-inline-end: 1rem;
+  }
+
+  starlight-menu-button button {
+      top: unset;
+      bottom: calc((var(--sl-mobile-toc-height) - var(--sl-menu-button-size)) / 2);
+      background-color: var(--color-gray-80);
+  }
+
   mobile-starlight-toc nav {
     top: unset;
     bottom: 0;
@@ -187,6 +196,10 @@
 
     .starlight-sidebar-topics-icon {
       background-color: var(--color-gray-20);
+    }
+
+    starlight-menu-button button {
+        background-color: var(--color-gray-20);
     }
   }
 }


### PR DESCRIPTION
This PR adds some custom CSS to make the placements of the search icon and menu button on mobile devices look better. It also fixes the background color of the menu button.

- Closes #43 