### PR TITLE
fix: override topics css styles to fix light mode colors

### DIFF
--- a/src/styles/starlight.css
+++ b/src/styles/starlight.css
@@ -157,6 +157,14 @@
     bottom: 0;
   }
 
+  .starlight-sidebar-topics-current .starlight-sidebar-topics-icon {
+      background-color: var(--color-gray-20) !important;
+  }
+
+  a:has(.starlight-sidebar-topics-icon):is(:hover, :focus-visible) .starlight-sidebar-topics-icon {
+      background-color: var(--color-gray-20) !important;
+  }
+
   /* Light theme specific overrides for better readability */
   :root[data-theme=light] {
     --sl-color-text: var(--color-gray-100);

--- a/src/styles/starlight.css
+++ b/src/styles/starlight.css
@@ -157,14 +157,6 @@
     bottom: 0;
   }
 
-  .starlight-sidebar-topics-current .starlight-sidebar-topics-icon {
-      background-color: var(--color-gray-20) !important;
-  }
-
-  a:has(.starlight-sidebar-topics-icon):is(:hover, :focus-visible) .starlight-sidebar-topics-icon {
-      background-color: var(--color-gray-20) !important;
-  }
-
   /* Light theme specific overrides for better readability */
   :root[data-theme=light] {
     --sl-color-text: var(--color-gray-100);
@@ -192,9 +184,13 @@
     .sl-link-button>svg {
       fill: var(--color-white-100);
     }
+  }
+}
 
+/* this rule must not be layered because the Starlight Sidebar Topics plugin doesn't use Cascade Layers */
+:root[data-theme="light"] {
+  a:is(.starlight-sidebar-topics-current, :hover, :focus-visible)
     .starlight-sidebar-topics-icon {
-      background-color: var(--color-gray-20);
-    }
+    background-color: var(--sl-color-accent-low);
   }
 }


### PR DESCRIPTION
#### Description

This PR sets the background color of the topic icons in light mode to the low accent color, so the contrast is accessible.

The CSS rules must stay outside the layer because Starlight Sidebar Topics CSS rules are not cascade layered. This fix is inspired by https://github.com/HiDeoo/starlight-sidebar-topics/pull/64#issuecomment-4599891969

- Closes #37