### PR TITLE
docs(clack): document async validation

### DIFF
--- a/src/content/docs/clack/packages/core.mdx
+++ b/src/content/docs/clack/packages/core.mdx
@@ -66,9 +66,11 @@ import {
   CANCEL_SYMBOL,
   updateSettings,
   settings,
+  runValidation,
 
   // Types
   type ClackSettings,
+  type Validate,
   type PromptOptions,
   type ConfirmOptions,
   type PasswordOptions,
@@ -141,6 +143,11 @@ p.on('value', (value?: string) => {
 // Handle submission
 p.on('submit', (value?: string) => {
   console.log('Submitted:', value);
+});
+
+// Fired when an async `validate` is pending; input is ignored until it settles (@clack/core v1.5.0)
+p.on('validating', (value?: string) => {
+  console.log('Validating:', value);
 });
 
 // Handle cancellation

--- a/src/content/docs/clack/packages/prompts.mdx
+++ b/src/content/docs/clack/packages/prompts.mdx
@@ -130,8 +130,30 @@ Options:
 - `placeholder`: A visual hint shown when the field has no content.
 - `defaultValue`: A fallback value returned when the user provides nothing (empty input).
 - `initialValue`: The starting value shown when the prompt first renders. Users can edit this value before submitting.
-- `validate`: A function or a [Standard Schema](https://github.com/standard-schema/standard-schema) that validates user input. If a custom function is given, you should return a `string` or `Error` to show as a validation error, or `undefined` to accept the result..
+- `validate`: A function or a [Standard Schema](https://github.com/standard-schema/standard-schema) that validates user input. If a custom function is given, you should return a `string` or `Error` to show as a validation error, or `undefined` to accept the result. May return a `Promise`; the prompt shows a validating state and blocks input until it resolves (v1.8.0).
 - All [Common Options](#common-options)
+
+Validation can be asynchronous (v1.8.0). While the promise is pending, the prompt ignores keypresses and shows a dim `Validating...` line. Async [Standard Schema](https://github.com/standard-schema/standard-schema) validators are supported too.
+
+```ts twoslash
+import { text } from '@clack/prompts';
+
+declare function isUsernameTaken(name: string): Promise<boolean>;
+
+const username = await text({
+  message: 'Pick a username',
+  validate: async (value) => {
+    if (!value) return 'Username is required';
+    if (await isUsernameTaken(value)) return 'That name is taken';
+    return undefined;
+  },
+});
+```
+
+<pre class="cli-preview"><font color="#555753">│</font>
+<font color="#AAAAAA">◆</font>  Pick a username
+<font color="#06989A">│</font>  <font color="#AAAAAA">ada</font>
+<font color="#06989A">└</font>  <font color="#AAAAAA">Validating...</font></pre>
 
 ### Password Input
 
@@ -163,7 +185,7 @@ Options:
 
 - `message`: The prompt message or question shown to the user above the input.
 - `mask`: Character to use for masking input. Default: `'▪/•'`.
-- `validate`: A function or a [Standard Schema](https://github.com/standard-schema/standard-schema) that validates user input. If a custom function is given, you should return a `string` or `Error` to show as a validation error, or `undefined` to accept the result.
+- `validate`: A function or a [Standard Schema](https://github.com/standard-schema/standard-schema) that validates user input. If a custom function is given, you should return a `string` or `Error` to show as a validation error, or `undefined` to accept the result. May return a `Promise`; the prompt blocks input until it resolves (v1.8.0).
 - `clearOnError`: When enabled it causes the input to be cleared if/when validation fails. Default: `false`.
 - Submitting with no input resolves to `""`, matching `text()` and the documented `Promise<string | symbol>` return type (v1.4.2).
 - All [Common Options](#common-options)
@@ -379,7 +401,7 @@ Options:
 - `maxItems`: The maximum number of items/options to display in the autocomplete list at once.
 - `placeholder`: Placeholder text displayed when the search field is empty. When set, pressing Tab on an empty input copies the placeholder into the input. This takes precedence over `completeOnTab`.
 - `completeOnTab`: When `true`, pressing Tab fills the input with the focused option's value and adds a `Tab: complete` hint to the footer. Single-select only; ignored with `multiple: true`. Default: `false` (v1.8.0).
-- `validate`: A function that validates user input. Return a `string` or `Error` to show as a validation error, or `undefined` to accept the result.
+- `validate`: A function that validates user input. Return a `string` or `Error` to show as a validation error, or `undefined` to accept the result. May return a `Promise`; the prompt blocks input until it resolves (v1.8.0).
 - `filter`: Custom filter function to match options against the search input.
 - `initialValue`: The initially selected option from the list.
 - `initialUserInput`: The starting value shown in the users input box.
@@ -501,7 +523,7 @@ Options:
 - `root`: The starting directory for path suggestions (defaults to current working directory).
 - `directory`: When `true` only **directories** appear in suggestions while you navigate (v1.2.0 fixes for directory-only mode).
 - `initialValue`: The starting path shown when the prompt first renders, which users can edit before submitting. If not provided it will fall back to the given `root`, or the current working directory. In `directory` mode, if the initial value points to a directory that exists, pressing enter will submit the input instead of jumping to the first child (v1.2.0).
-- `validate`: A function that validates the given path. Return a `string` or `Error` to show as a validation error, or `undefined` to accept the result.
+- `validate`: A function that validates the given path. Return a `string` or `Error` to show as a validation error, or `undefined` to accept the result. May return a `Promise`; the prompt blocks input until it resolves (v1.8.0).
 - All [Common Options](#common-options)
 
 ### Date input
@@ -528,7 +550,7 @@ Options:
 - `initialValue`: The starting date shown when the prompt first renders. Users can edit this value before submitting.
 - `minDate`: The minimum allowed date for validation.
 - `maxDate`: The maximum allowed date for validation.
-- `validate`: A function or a [Standard Schema](https://github.com/standard-schema/standard-schema) that validates user input. If a custom function is given, you should return a `string` or `Error` to show as a validation error, or `undefined` to accept the result..
+- `validate`: A function or a [Standard Schema](https://github.com/standard-schema/standard-schema) that validates user input. If a custom function is given, you should return a `string` or `Error` to show as a validation error, or `undefined` to accept the result. May return a `Promise`; the prompt blocks input until it resolves (v1.8.0).
 - All [Common Options](#common-options)
 
 ### Confirmation


### PR DESCRIPTION
## What does this PR do?

documents async `validate` (v1.8.0) on the reference pages: every `validate` bullet in prompts now notes it may return a promise and blocks input until it resolves, the text prompt gets an async example with the `Validating...` preview, and core lists the new `validating` event alongside the `Validate` type and `runValidation` export. also fixes the stray double period on the text and date bullets.

## Type of change

- [ ] Typo
- [x] New Documentation for Feature
- [ ] Improvement for Clarification
- [ ] Chore (dependencies, CI, tooling)

## AI-generated code disclosure

- [ ] This PR includes AI-generated code
