### PR TITLE
fix: cli-preview code block mobile overflow

### DIFF
--- a/src/styles/starlight.css
+++ b/src/styles/starlight.css
@@ -384,7 +384,6 @@
     font-family: var(--sl-font-mono);
     background-color: var(--container-fill);
     color: var(--color-white-100);
-
     overflow-x: auto;
     max-width: 100%;
   }

--- a/src/styles/starlight.css
+++ b/src/styles/starlight.css
@@ -384,6 +384,9 @@
     font-family: var(--sl-font-mono);
     background-color: var(--container-fill);
     color: var(--color-white-100);
+
+    overflow-x: auto;
+    max-width: 100%;
   }
 
   /* Code frames — subtle gradient fade on terminal/editor title bars,


### PR DESCRIPTION
## What does this PR do?

As Chris noticed on Discord, the [prompts docs page](https://bomb.sh/docs/clack/packages/prompts/#selection) has some horizontal overflow when viewing on smaller screens. This is because the custom code blocks with `<pre>` (`cli-preview`s) did not have any `overflow-x` rules. This PR adds them and a `max-width: 100%` to comply on mobile devices.

## Type of change

<!-- Check one. -->

- [ ] Typo
- [ ] New Documentation for Feature
- [ ] Improvement for Clarification
- [ ] Chore (dependencies, CI, tooling)
- [x] Fix styling

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [x] This PR includes AI-generated code (suggested the CSS properties)
